### PR TITLE
GitIgnore OS Generated Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ target/
 # logs #
 *.log
 logs/
+
+# Hide MacOS DS_Store #
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,12 @@ target/
 *.log
 logs/
 
-# Hide MacOS DS_Store #
-*.DS_Store
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
Ignores MacOS and Windows generated files, stop the repo getting full of those annoying .DS_Store or .thumbs files early on..